### PR TITLE
Updated hapi to version 10.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "code": "1.5.0",
-    "hapi": "8.8.1",
+    "hapi": "10.1.0",
     "lab": "6.1.0"
   },
   "dependencies": {


### PR DESCRIPTION
:rocket:

hapi just published version 10.1.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 108 commits (ahead by 108, behind by 0).

- [c2f6752](https://github.com/hapijs/hapi/commit/c2f67521561d63610b2ab3e031d895dd049c1dbb): Fix null request.state. Closes #2505
- [6f05a51](https://github.com/hapijs/hapi/commit/6f05a5138f2e23eb7e800c5bf458a57662eee6c7): Upgrade dependencies. Closes #2781. Closes #2782. Closes #2783. Closes #2784. Closes #2785. Closes #2786. Closes #2787
- [c1098ae](https://github.com/hapijs/hapi/commit/c1098aecc6522bbb79a6ced9553885ee65009a97): Merge branch 'master' of github.com:hapijs/hapi
- [aa22e6c](https://github.com/hapijs/hapi/commit/aa22e6c767678f1261eae5e845ffdd0f23d234ac): Fix test on windows. Closes #2762
- [e3b8082](https://github.com/hapijs/hapi/commit/e3b8082f177f1248d5809c2794f7d2ccaf8dab25): Merge pull request #2776 from analytically/master
- [5316fae](https://github.com/hapijs/hapi/commit/5316fae628aabfe22066d648904c39d1f7389516): Merge pull request #2780 from hulbert/master
- [7ed102b](https://github.com/hapijs/hapi/commit/7ed102b4bc0031c4da3d382ed45ac1f2785fc71a): update docs link to Joi docs because Joi moved docs into API.md
- [9f1a2a1](https://github.com/hapijs/hapi/commit/9f1a2a1bd80c26bcffd9a2fea5683bd30e6a42eb): 10.0.1
- [99e40d4](https://github.com/hapijs/hapi/commit/99e40d47b8da8f29a8d7085fa9e29e951585ae23): Merge branch 'master' of github.com:hapijs/hapi
- [52abd37](https://github.com/hapijs/hapi/commit/52abd37b98f68077a352a02726f4c6743bdaa6fc): Test incorrect timing. Closes #2779
- [028e0a5](https://github.com/hapijs/hapi/commit/028e0a58279c09f61d01159815e2abc9451db076): Merge pull request #2775 from toboid/after-docs
- [183f685](https://github.com/hapijs/hapi/commit/183f685a71e3153343094ef6cec95067bddcdf12): Rename server to srv
- [9d78a66](https://github.com/hapijs/hapi/commit/9d78a668838590b5989f67dd167a8d9be195a95e): Fix tests and add support for includeSubDomains param too (backwards compatible).
- [348f2bc](https://github.com/hapijs/hapi/commit/348f2bc776cf4a680a7ad6785224e3cf236cbeca): Add preload flag to HSTS header.
- [e2721e8](https://github.com/hapijs/hapi/commit/e2721e8f0e531dc2220826f74f2ec3ad3ecaaabf): Add next to docs example for server.after


There are 108 commits in total. See the [full diff](https://github.com/hapijs/hapi/compare/bc722ef68407c398178e72b104c4ee7e8eb4c696...c2f67521561d63610b2ab3e031d895dd049c1dbb).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>