### PR TITLE
added ability to recurse a globbed directory of routes files

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ const server = new Hapi.server();
 await server.register({
   plugin: require('hapi-routes'),
   options: {
-    dir: `${__dirname}/test/routes`,
+    dir: `${__dirname}/test/routes/*`,
   },
 });
 ```
@@ -21,11 +21,9 @@ await server.register({
 `options` take the following arguments:
 ```
 {
-  dir: String,    // (Required): relative path where to search for route files.
-  test: RegExp,   // (Optional): regular expression for matching files, defaults to /\.(js)$/
-  glob: Boolean   // (Optional): When 'true' this will glob all files in the provided
-                                 directory. Requires a globable path: 'routes/*',
-                                 'routes/**/*.js', etc
+  dir: String,  // (Required): Relative path where to search for route files.
+                               Requires a globable path: 'routes/*', 'routes/**/*.js', etc
+  test: RegExp, // (Optional): Regular expression for matching files, defaults to /\.(js)$/
 }
 ```
 In the example the routes are located in `test/routes` relative to the `server.js` module.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ await server.register({
 {
   dir: String,    // (Required): relative path where to search for route files.
   test: RegExp,   // (Optional): regular expression for matching files, defaults to /\.(js)$/
+  glob: Boolean   // (Optional): When 'true' this will glob all files in the provided
+                                 directory. Requires a globable path: 'routes/*',
+                                 'routes/**/*.js', etc
 }
 ```
 In the example the routes are located in `test/routes` relative to the `server.js` module.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,14 +1,17 @@
 'use strict';
 
 const Fs = require('fs');
-const Path = require('path');
 const Util = require('util');
 const Glob = require('glob');
 
 const internals = {
-    readDir: Util.promisify(Fs.readdir),
     testDefault: /\.(js)$/,
-    glob: Util.promisify(Glob)
+    glob: Util.promisify(Glob),
+    checkPath: (path) => {
+
+        const chunk = path.replace(/[\/\*]+$/, '');
+        return Util.promisify(Fs.exists)(chunk);
+    }
 };
 
 module.exports = {
@@ -17,7 +20,7 @@ module.exports = {
 
         const fileTest = options.test || internals.testDefault;
 
-        if (options.glob === true) {
+        if (await internals.checkPath(options.dir)) {
             const fileList = await internals.glob(options.dir);
             fileList.forEach((file) => {
 
@@ -29,16 +32,7 @@ module.exports = {
             });
         }
         else {
-            const fileList = await internals.readDir(options.dir);
-            fileList.forEach((file) => {
-
-                if (file.match(fileTest)) {
-                    const modulePath = Path.join(options.dir, file);
-                    const routeFile = require(modulePath);
-
-                    routeFile.routes(server);
-                }
-            });
+            throw new Error(`'${options.dir}' is not a valid glob path (e.g. routes/**/*)`);
         }
 
         server.log(['hapi-routes'], `Registered all routes in ${options.dir}`);

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@ const Glob = require('glob');
 const internals = {
     readDir: Util.promisify(Fs.readdir),
     testDefault: /\.(js)$/,
-    glob: Glob.sync
+    glob: Util.promisify(Glob)
 };
 
 module.exports = {
@@ -17,8 +17,8 @@ module.exports = {
 
         const fileTest = options.test || internals.testDefault;
 
-        if ('glob' in options && options.glob === true) {
-            const fileList = internals.glob(options.dir);
+        if (options.glob === true) {
+            const fileList = await internals.glob(options.dir);
             fileList.forEach((file) => {
 
                 if (file.match(fileTest)) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,17 +1,11 @@
 'use strict';
 
-const Fs = require('fs');
 const Util = require('util');
 const Glob = require('glob');
 
 const internals = {
     testDefault: /\.(js)$/,
-    glob: Util.promisify(Glob),
-    checkPath: (path) => {
-
-        const chunk = path.replace(/[\/\*]+$/, '');
-        return Util.promisify(Fs.exists)(chunk);
-    }
+    glob: Util.promisify(Glob)
 };
 
 module.exports = {
@@ -19,21 +13,20 @@ module.exports = {
     register: async (server, options) => {
 
         const fileTest = options.test || internals.testDefault;
+        const fileList = await internals.glob(options.dir);
 
-        if (await internals.checkPath(options.dir)) {
-            const fileList = await internals.glob(options.dir);
-            fileList.forEach((file) => {
-
-                if (file.match(fileTest)) {
-                    const routeFile = require(file);
-
-                    routeFile.routes(server);
-                }
-            });
+        if (!(fileList.length > 0)) {
+            throw new Error(`Invalid Path: '${options.dir}' is not a valid path`);
         }
-        else {
-            throw new Error(`'${options.dir}' is not a valid glob path (e.g. routes/**/*)`);
-        }
+
+        fileList.forEach((file) => {
+
+            if (file.match(fileTest)) {
+                const routeFile = require(file);
+
+                routeFile.routes(server);
+            }
+        });
 
         server.log(['hapi-routes'], `Registered all routes in ${options.dir}`);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,28 +3,43 @@
 const Fs = require('fs');
 const Path = require('path');
 const Util = require('util');
+const Glob = require('glob');
 
 const internals = {
     readDir: Util.promisify(Fs.readdir),
-    testDefault: /\.(js)$/
+    testDefault: /\.(js)$/,
+    glob: Glob.sync
 };
 
 module.exports = {
     pkg: require('../package.json'),
     register: async (server, options) => {
 
-        const fileList = await internals.readDir(options.dir);
         const fileTest = options.test || internals.testDefault;
 
-        fileList.forEach((file) => {
+        if ('glob' in options && options.glob === true) {
+            const fileList = internals.glob(options.dir);
+            fileList.forEach((file) => {
 
-            if (file.match(fileTest)) {
-                const modulePath = Path.join(options.dir, file);
-                const routeFile = require(modulePath);
+                if (file.match(fileTest)) {
+                    const routeFile = require(file);
 
-                routeFile.routes(server);
-            }
-        });
+                    routeFile.routes(server);
+                }
+            });
+        }
+        else {
+            const fileList = await internals.readDir(options.dir);
+            fileList.forEach((file) => {
+
+                if (file.match(fileTest)) {
+                    const modulePath = Path.join(options.dir, file);
+                    const routeFile = require(modulePath);
+
+                    routeFile.routes(server);
+                }
+            });
+        }
 
         server.log(['hapi-routes'], `Registered all routes in ${options.dir}`);
     }

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
     "code": "5.x.x",
     "hapi": "17.x.x",
     "lab": "15.x.x"
+  },
+  "dependencies": {
+    "glob": "^7.1.2"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -38,6 +38,18 @@ lab.experiment('With right settings', () => {
         expect(server.table().length).to.equal(2);
     });
 
+    it('Adds all the routes in the globbed routes folder to the server (options: glob)', async () => {
+
+        const server = new Hapi.server();
+
+        await server.register({
+            plugin: require('../'),
+            options: { dir: `${testRoutePath}/**/*.js`, glob: true }
+        });
+
+        expect(server.table().length).to.equal(4);
+    });
+
     it('Does not add anything when RegExp matches no files', async () => {
 
         const server = new Hapi.server();

--- a/test/index.js
+++ b/test/index.js
@@ -94,7 +94,7 @@ lab.experiment('With wrong settings', () => {
         }
         catch (err) {
             expect(err).to.exist();
-            expect(err.message).to.include('is not a valid glob path');
+            expect(err.message).to.include('is not a valid path');
             return;
         }
 

--- a/test/index.js
+++ b/test/index.js
@@ -8,8 +8,8 @@ const lab = exports.lab = Lab.script();
 const { it } = lab;
 const { expect, fail } = Lab.assertions;
 
-const testRoutePath = Path.join(__dirname, 'routes');
-
+const testRoutePath = Path.join(__dirname, 'routes/*');
+const testRouteNestedPath = Path.join(__dirname, 'routes/**/*');
 
 lab.experiment('With right settings', () => {
 
@@ -44,7 +44,7 @@ lab.experiment('With right settings', () => {
 
         await server.register({
             plugin: require('../'),
-            options: { dir: `${testRoutePath}/**/*`, glob: true }
+            options: { dir: testRouteNestedPath, glob: true }
         });
 
         expect(server.table().length).to.equal(4);
@@ -94,7 +94,7 @@ lab.experiment('With wrong settings', () => {
         }
         catch (err) {
             expect(err).to.exist();
-            expect(err.message).to.include('ENOENT');
+            expect(err.message).to.include('is not a valid glob path');
             return;
         }
 

--- a/test/index.js
+++ b/test/index.js
@@ -44,7 +44,7 @@ lab.experiment('With right settings', () => {
 
         await server.register({
             plugin: require('../'),
-            options: { dir: `${testRoutePath}/**/*.js`, glob: true }
+            options: { dir: `${testRoutePath}/**/*`, glob: true }
         });
 
         expect(server.table().length).to.equal(4);

--- a/test/routes/glob/badRegex.py
+++ b/test/routes/glob/badRegex.py
@@ -1,0 +1,1 @@
+# for test only

--- a/test/routes/glob/testGlobRoute1.js
+++ b/test/routes/glob/testGlobRoute1.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const routes = [
+    {
+        method: '*',
+        path: '/glob/1',
+        handler: function (request, reply) {
+
+            return reply('Hello 1');
+        }
+    }
+];
+
+exports.routes = function (server) {
+
+    return server.route(routes);
+};

--- a/test/routes/glob/testGlobRoute2.js
+++ b/test/routes/glob/testGlobRoute2.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const routes = [
+    {
+        method: '*',
+        path: '/glob/2',
+        handler: function (request, reply) {
+
+            return reply('Hello 2');
+        }
+    }
+];
+
+exports.routes = function (server) {
+
+    return server.route(routes);
+};


### PR DESCRIPTION
Moved from using `Fs.readdir` to using  the `glob` module to recursively return an array of all files that match the glob pattern in a directory.

We would like to structure the routes directory with more depth, like so:

```
lib/routes/
├── healthcheck.js
├── v1
│   └── job
│       └── campaign.js
├── v2
│   └── job
│       └── campaign.js
└── version.js
```

This will allow for more clearly defined routes directories with the use of `hapi-routes`.

  